### PR TITLE
Fix openssl 1.1 warning

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -18,7 +18,7 @@ It is intended to protect against information disclosure in the event of acciden
 
 ```
 dd if=/dev/random bs=1c count=256 | base64 > unencrypted_keyfile
-cat unencrypted_keyfile | openssl enc -base64 -aes-256-cbc -md sha256 -e -salt -out encrypted_keyfile -k somepassphrase
+cat unencrypted_keyfile | openssl enc -base64 -aes-256-cbc -md sha256 -e -salt -pbkdf2 -out encrypted_keyfile -k somepassphrase
 rm unencrypted_keyfile
 ```
 

--- a/src/lib/cryptsetup/scripts/wget_or_ask
+++ b/src/lib/cryptsetup/scripts/wget_or_ask
@@ -152,7 +152,7 @@ https_try_fetch ()
   encrypted_keyfile=$($wget_path --secure-protocol=PFS -q -O - "$url")
 
   if [ $? -eq 0 ]; then
-    decrypted_keyfile=$(echo "$encrypted_keyfile" | openssl enc -base64 -aes-256-cbc -md sha256 -d -salt -k "$openssl_passphrase")
+    decrypted_keyfile=$(echo "$encrypted_keyfile" | openssl enc -base64 -aes-256-cbc -md sha256 -d -salt -pbkdf2 -k "$openssl_passphrase")
     if [ $? -eq 0 ]; then
       keyctl_store
       printf '%s\n' "$decrypted_keyfile"


### PR DESCRIPTION
Newer distros have openssl 1.1 on board nowadays. (Fixes https://github.com/stupidpupil/https-keyscript/issues/7)